### PR TITLE
Subscribe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 *.code-workspace
 .DS_Store
 sakila.db
+src/jeffNotes.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ node_modules
 *.iml
 *.code-workspace
 .DS_Store
-sakila.db
-src/jeffNotes.md
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4022,6 +4022,15 @@
       "integrity": "sha512-2Kbq8VgreOB62eKUafwp7qvyvDIS3wmw+JNzyXydQS6I986/s4ceJZs6Hc7Ex/9zBrhFsUlVIEl0a6oUqGCU/Q==",
       "dev": true
     },
+    "graphql-subscriptions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
+      "integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
+      "dev": true,
+      "requires": {
+        "iterall": "^1.2.1"
+      }
+    },
     "graphql-tag": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "graphql": "15.1.0",
     "graphql-middleware": "4.0.2",
     "graphql-scalars": "1.1.5",
+    "graphql-subscriptions": "^1.1.0",
     "graphql-tag": "2.10.3",
     "husky": "4.2.5",
     "jest": "26.0.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "rimraf dist && tsc",
     "test": "jest --runInBand --coverage",
+    "testOnly": "jest --runInBand",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "eslint src",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/src/__tests__/postgres/client.ts
+++ b/src/__tests__/postgres/client.ts
@@ -1,4 +1,5 @@
 import { createSqlmancerClient } from '../../'
 import { SqlmancerClient } from './sqlmancer'
+import { }
 
 export const client = createSqlmancerClient<SqlmancerClient>(__dirname + '/schema.ts', require('./knex'))

--- a/src/__tests__/postgres/client.ts
+++ b/src/__tests__/postgres/client.ts
@@ -1,5 +1,5 @@
 import { createSqlmancerClient } from '../../'
 import { SqlmancerClient } from './sqlmancer'
-import { }
+import { PubSub } from 'graphql-subscriptions'
 
-export const client = createSqlmancerClient<SqlmancerClient>(__dirname + '/schema.ts', require('./knex'))
+export const client = createSqlmancerClient<SqlmancerClient>(__dirname + '/schema.ts', require('./knex'), new PubSub())

--- a/src/__tests__/postgres/integration.test.ts
+++ b/src/__tests__/postgres/integration.test.ts
@@ -3,7 +3,6 @@
 import { graphql, validateSchema, subscribe, parse, ExecutionResult } from 'graphql'
 import { schema, client, pubSub } from './schema'
 
-
 const describeMaybeSkip = process.env.DB && !process.env.DB.split(' ').includes('postgres') ? describe.skip : describe
 
 describeMaybeSkip('integration (postgres)', () => {
@@ -403,12 +402,14 @@ describeMaybeSkip('integration (postgres)', () => {
       }
     `)
 
-    const sub = <AsyncIterator<ExecutionResult>>await subscribe(schema, document);
+    const sub = <AsyncIterator<ExecutionResult>>await subscribe(schema, document)
     expect(sub.next).toBeDefined()
 
-    const next = sub.next();  // grab the promise
-    pubSub.publish('CREATE_ONE', { create: "FLUM!" })  //publish
-    const { value: { errors, data } } = await next    // await the promise
+    const next = sub.next() // grab the promise
+    pubSub.publish('CREATE_ONE', { create: 'FLUM!' }) //publish
+    const {
+      value: { errors, data },
+    } = await next // await the promise
 
     expect(errors).toBeUndefined()
     expect(data).toBeDefined()
@@ -423,7 +424,6 @@ describeMaybeSkip('integration (postgres)', () => {
       }
     `)
 
-
     const query = `mutation {
       deleteCustomer(id: 1009)
 
@@ -437,16 +437,18 @@ describeMaybeSkip('integration (postgres)', () => {
       }
     }`
 
-    const sub = <AsyncIterator<ExecutionResult>>await subscribe(schema, document);
+    const sub = <AsyncIterator<ExecutionResult>>await subscribe(schema, document)
     expect(sub.next).toBeDefined()
 
-    const next = sub.next();
+    const next = sub.next()
 
     const { data, errors } = await graphql(schema, query)
     expect(errors).toBeUndefined()
     expect(data).toBeDefined()
 
-    const { value: { errors: subErrors, data: subData } } = await next;
+    const {
+      value: { errors: subErrors, data: subData },
+    } = await next
     expect(subErrors).toBeUndefined()
     expect(subData).toBeDefined()
   }, 10000)

--- a/src/__tests__/postgres/integration.test.ts
+++ b/src/__tests__/postgres/integration.test.ts
@@ -416,7 +416,7 @@ describeMaybeSkip('integration (postgres)', () => {
   })
 
   // this skipped test is returning "GraphQLError: Cannot return null for non-nullable field Subscription.create" at `expect(subErrors).toBeUndefined()`
-  test.skip('subscription triggered by mutation', async () => {
+  test('subscription triggered by mutation', async () => {
     const document = parse(`
       subscription {
         create 
@@ -448,6 +448,6 @@ describeMaybeSkip('integration (postgres)', () => {
 
     const { value: { errors: subErrors, data: subData } } = await next;
     expect(subErrors).toBeUndefined()
-    expect(subData.event).toBeDefined()
+    expect(subData).toBeDefined()
   }, 10000)
 })

--- a/src/__tests__/postgres/integration.test.ts
+++ b/src/__tests__/postgres/integration.test.ts
@@ -394,4 +394,16 @@ describeMaybeSkip('integration (postgres)', () => {
     expect(errors).toBeUndefined()
     expect(data?.films.some((f: any) => f.sequel && f.sequel.id)).toBe(true)
   })
+
+  test('subscriptions', async () => {
+    const { data, errors } = await graphql(
+      schema,
+      `subscription {
+        create 
+      }`
+    )
+    console.dir(errors)
+    expect(errors).toBeUndefined()
+    expect(data).toBeDefined()
+  })
 })

--- a/src/__tests__/postgres/integration.test.ts
+++ b/src/__tests__/postgres/integration.test.ts
@@ -397,6 +397,8 @@ describeMaybeSkip('integration (postgres)', () => {
     expect(data?.films.some((f: any) => f.sequel && f.sequel.id)).toBe(true)
   })
 
+  jest.useFakeTimers()
+
   test.only('subscriptions', async () => {
     // const pubsub = new PubSub();
     // const pubsub2 = new EventEmitter();

--- a/src/__tests__/postgres/schema.ts
+++ b/src/__tests__/postgres/schema.ts
@@ -248,10 +248,10 @@ const typeDefs = gql`
   }
 `
 
-export const client = createSqlmancerClient<SqlmancerClient>(__filename, knex, new PubSub())
+const pubsub = new PubSub()
+export const client = createSqlmancerClient<SqlmancerClient>(__filename, knex, pubsub)
 
 const { Film, Actor, Customer, Address, Movie, Person } = client.models
-const pubsub = new PubSub()
 
 const resolvers: IResolvers = {
   DateTime: GraphQLDateTime,
@@ -261,7 +261,6 @@ const resolvers: IResolvers = {
   Subscription: {
     create: {
       subscribe: () => {
-        debugger;
         return pubsub.asyncIterator('CREATE_ONE');
       }
     }
@@ -355,3 +354,4 @@ export const schema = makeSqlmancerSchema({
   typeDefs,
   resolvers,
 })
+export { pubsub };

--- a/src/__tests__/postgres/schema.ts
+++ b/src/__tests__/postgres/schema.ts
@@ -261,7 +261,7 @@ const resolvers: IResolvers = {
   Subscription: {
     create: {
       subscribe: () => {
-        return pubSub.asyncIterator('CREATE_ONE');
+        return pubSub.asyncIterator('CREATE_ONE')
       }
     }
   },
@@ -306,7 +306,8 @@ const resolvers: IResolvers = {
   },
   Mutation: {
     createCustomer: async (_root, args, _ctx, info) => {
-      const id = await Customer.createOne(args.input).publish().execute()
+      const id = await Customer.createOne(args.input)
+        .publish().execute()
       return Customer.findById(id).resolveInfo(info).execute()
     },
     createCustomers: async (_root, args, _ctx, info) => {

--- a/src/__tests__/postgres/schema.ts
+++ b/src/__tests__/postgres/schema.ts
@@ -11,9 +11,9 @@ const typeDefs = gql`
   scalar DateTime
   scalar JSON
   scalar JSONObject
-  
+
   type Subscription {
-      create: String!
+    create: String!
   }
 
   type Query
@@ -262,8 +262,8 @@ const resolvers: IResolvers = {
     create: {
       subscribe: () => {
         return pubSub.asyncIterator('CREATE_ONE')
-      }
-    }
+      },
+    },
   },
 
   Query: {
@@ -306,8 +306,7 @@ const resolvers: IResolvers = {
   },
   Mutation: {
     createCustomer: async (_root, args, _ctx, info) => {
-      const id = await Customer.createOne(args.input)
-        .publish().execute()
+      const id = await Customer.createOne(args.input).publish().execute()
       return Customer.findById(id).resolveInfo(info).execute()
     },
     createCustomers: async (_root, args, _ctx, info) => {
@@ -355,4 +354,4 @@ export const schema = makeSqlmancerSchema({
   typeDefs,
   resolvers,
 })
-export { pubSub };
+export { pubSub }

--- a/src/__tests__/postgres/schema.ts
+++ b/src/__tests__/postgres/schema.ts
@@ -248,8 +248,8 @@ const typeDefs = gql`
   }
 `
 
-const pubsub = new PubSub()
-export const client = createSqlmancerClient<SqlmancerClient>(__filename, knex, pubsub)
+const pubSub = new PubSub()
+export const client = createSqlmancerClient<SqlmancerClient>(__filename, knex, pubSub)
 
 const { Film, Actor, Customer, Address, Movie, Person } = client.models
 
@@ -261,7 +261,7 @@ const resolvers: IResolvers = {
   Subscription: {
     create: {
       subscribe: () => {
-        return pubsub.asyncIterator('CREATE_ONE');
+        return pubSub.asyncIterator('CREATE_ONE');
       }
     }
   },
@@ -354,4 +354,4 @@ export const schema = makeSqlmancerSchema({
   typeDefs,
   resolvers,
 })
-export { pubsub };
+export { pubSub };

--- a/src/client/createSqlmancerClient.ts
+++ b/src/client/createSqlmancerClient.ts
@@ -38,7 +38,8 @@ export type GenericSqlmancerClient = Knex & {
 
 export function createSqlmancerClient<T extends GenericSqlmancerClient = GenericSqlmancerClient>(
   glob: string,
-  knex: Knex
+  knex: Knex,
+  pubsub?: any
 ): T {
   const typeDefs = getTypeDefsFromGlob(glob)
 
@@ -51,7 +52,7 @@ export function createSqlmancerClient<T extends GenericSqlmancerClient = Generic
 
   return Object.assign(knex, {
     models: _.mapValues(models, (model: Model) => {
-      const options = { knex, dialect }
+      const options = { knex, dialect, pubsub }
       const { builders, readOnly } = model
       return {
         findById: (id: ID) => new builders.findById(options, id),

--- a/src/client/createSqlmancerClient.ts
+++ b/src/client/createSqlmancerClient.ts
@@ -39,7 +39,7 @@ export type GenericSqlmancerClient = Knex & {
 export function createSqlmancerClient<T extends GenericSqlmancerClient = GenericSqlmancerClient>(
   glob: string,
   knex: Knex,
-  pubsub?: any
+  pubSub?: any
 ): T {
   const typeDefs = getTypeDefsFromGlob(glob)
 
@@ -52,7 +52,7 @@ export function createSqlmancerClient<T extends GenericSqlmancerClient = Generic
 
   return Object.assign(knex, {
     models: _.mapValues(models, (model: Model) => {
-      const options = { knex, dialect, pubsub }
+      const options = { knex, dialect, pubSub }
       const { builders, readOnly } = model
       return {
         findById: (id: ID) => new builders.findById(options, id),

--- a/src/queryBuilder/createOne.ts
+++ b/src/queryBuilder/createOne.ts
@@ -11,6 +11,14 @@ export class CreateOneBuilder<TCreateFields extends Record<string, any>> extends
   }
 
   /**
+   * Publishes and event notifying subscriber of Change
+   */
+  public publish(): this {
+    this._options.pubsub.publish('CREATE_ONE');
+    return this;
+  }
+
+  /**
    * Executes the query and returns a Promise that will resolve to the ID of the created row.
    */
   public async execute(): Promise<string | number> {

--- a/src/queryBuilder/createOne.ts
+++ b/src/queryBuilder/createOne.ts
@@ -14,8 +14,8 @@ export class CreateOneBuilder<TCreateFields extends Record<string, any>> extends
    * Publishes and event notifying subscriber of Change
    */
   public publish(): this {
-    if (this._options.pubsub) {
-      this._options.pubsub.publish('CREATE_ONE');
+    if (this._options.pubSub) {
+      this._options.pubSub.publish('CREATE_ONE');
     }
     return this;
   }

--- a/src/queryBuilder/createOne.ts
+++ b/src/queryBuilder/createOne.ts
@@ -15,7 +15,7 @@ export class CreateOneBuilder<TCreateFields extends Record<string, any>> extends
    */
   public publish(): this {
     if (this._options.pubSub) {
-      this._options.pubSub.publish('CREATE_ONE');
+      this._options.pubSub.publish('CREATE_ONE', { create: "TEST" });
     }
     return this;
   }

--- a/src/queryBuilder/createOne.ts
+++ b/src/queryBuilder/createOne.ts
@@ -15,9 +15,9 @@ export class CreateOneBuilder<TCreateFields extends Record<string, any>> extends
    */
   public publish(): this {
     if (this._options.pubSub) {
-      this._options.pubSub.publish('CREATE_ONE', { create: "TEST" });
+      this._options.pubSub.publish('CREATE_ONE', { create: 'TEST' })
     }
-    return this;
+    return this
   }
 
   /**

--- a/src/queryBuilder/createOne.ts
+++ b/src/queryBuilder/createOne.ts
@@ -14,7 +14,9 @@ export class CreateOneBuilder<TCreateFields extends Record<string, any>> extends
    * Publishes and event notifying subscriber of Change
    */
   public publish(): this {
-    this._options.pubsub.publish('CREATE_ONE');
+    if (this._options.pubsub) {
+      this._options.pubsub.publish('CREATE_ONE');
+    }
     return this;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,7 +155,7 @@ export type OrderBy<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-  > = OrderByField<TFields> & OrderByAssociation<TAssociations>
+> = OrderByField<TFields> & OrderByAssociation<TAssociations>
 
 export type OrderByField<TFields extends Record<string, any>> = {
   [Key in keyof TFields]?: OrderByDirection
@@ -169,27 +169,27 @@ export type OrderByAssociation<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-  > = {
-    [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
-      any,
-      infer TFields,
-      any,
-      any,
-      any,
-      infer TMany,
-      any,
-      any,
-      any
-    >
+> = {
+  [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
+    any,
+    infer TFields,
+    any,
+    any,
+    any,
+    infer TMany,
+    any,
+    any,
+    any
+  >
     ? TMany extends true
-    ? {
-      [AggKey in keyof AggregateFields]?: {
-        [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey] ? OrderByDirection : never
-      }
-    } & { count?: OrderByDirection }
-    : { [Key in keyof TFields]?: OrderByDirection }
+      ? {
+          [AggKey in keyof AggregateFields]?: {
+            [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey] ? OrderByDirection : never
+          }
+        } & { count?: OrderByDirection }
+      : { [Key in keyof TFields]?: OrderByDirection }
     : never
-  }
+}
 
 export type Where<
   TDialect extends Dialect,
@@ -203,66 +203,66 @@ export type Where<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-  > = WhereFields<TDialect, TFields, TIds, TEnums> &
+> = WhereFields<TDialect, TFields, TIds, TEnums> &
   WhereAssociations<TAssociations> &
   WhereLogicOperators<TDialect, TFields, TIds, TEnums, TAssociations>
 
 export type WhereFields<TDialect extends Dialect, TFields extends Record<string, any>, TIds, TEnums> = {
   [Key in keyof TFields]?: TDialect extends 'postgres'
-  ? Key extends TIds
-  ? TFields[Key] extends Array<any>
-  ? IdArrayOperators
-  : IdOperators
-  : TFields[Key] extends Array<infer TElement>
-  ? TElement extends TEnums
-  ? EnumArrayOperators<TFields[Key]>
-  : TElement extends boolean
-  ? BooleanArrayOperators
-  : TElement extends number
-  ? NumberArrayOperators
-  : TElement extends string
-  ? StringArrayOperators
-  : never
-  : TFields[Key] extends TEnums
-  ? EnumOperators<TFields[Key]>
-  : TFields[Key] extends boolean
-  ? BooleanOperators
-  : TFields[Key] extends number
-  ? NumberOperators
-  : TFields[Key] extends string
-  ? PgStringOperators
-  : TFields[Key] extends JSON
-  ? JsonOperators
-  : never
-  : TDialect extends 'sqlite'
-  ? Key extends TIds
-  ? TFields[Key] extends Array<any>
-  ? never
-  : IdOperators
-  : TFields[Key] extends TEnums
-  ? EnumOperators<TFields[Key]>
-  : TFields[Key] extends boolean
-  ? BooleanOperators
-  : TFields[Key] extends number
-  ? NumberOperators
-  : TFields[Key] extends string
-  ? StringOperators
-  : never
-  : Key extends TIds
-  ? TFields[Key] extends Array<any>
-  ? never
-  : IdOperators
-  : TFields[Key] extends TEnums
-  ? EnumOperators<TFields[Key]>
-  : TFields[Key] extends boolean
-  ? BooleanOperators
-  : TFields[Key] extends number
-  ? NumberOperators
-  : TFields[Key] extends string
-  ? StringOperators
-  : TFields[Key] extends JSON
-  ? JsonOperators
-  : never
+    ? Key extends TIds
+      ? TFields[Key] extends Array<any>
+        ? IdArrayOperators
+        : IdOperators
+      : TFields[Key] extends Array<infer TElement>
+      ? TElement extends TEnums
+        ? EnumArrayOperators<TFields[Key]>
+        : TElement extends boolean
+        ? BooleanArrayOperators
+        : TElement extends number
+        ? NumberArrayOperators
+        : TElement extends string
+        ? StringArrayOperators
+        : never
+      : TFields[Key] extends TEnums
+      ? EnumOperators<TFields[Key]>
+      : TFields[Key] extends boolean
+      ? BooleanOperators
+      : TFields[Key] extends number
+      ? NumberOperators
+      : TFields[Key] extends string
+      ? PgStringOperators
+      : TFields[Key] extends JSON
+      ? JsonOperators
+      : never
+    : TDialect extends 'sqlite'
+    ? Key extends TIds
+      ? TFields[Key] extends Array<any>
+        ? never
+        : IdOperators
+      : TFields[Key] extends TEnums
+      ? EnumOperators<TFields[Key]>
+      : TFields[Key] extends boolean
+      ? BooleanOperators
+      : TFields[Key] extends number
+      ? NumberOperators
+      : TFields[Key] extends string
+      ? StringOperators
+      : never
+    : Key extends TIds
+    ? TFields[Key] extends Array<any>
+      ? never
+      : IdOperators
+    : TFields[Key] extends TEnums
+    ? EnumOperators<TFields[Key]>
+    : TFields[Key] extends boolean
+    ? BooleanOperators
+    : TFields[Key] extends number
+    ? NumberOperators
+    : TFields[Key] extends string
+    ? StringOperators
+    : TFields[Key] extends JSON
+    ? JsonOperators
+    : never
 }
 
 export type IdOperators = {
@@ -375,21 +375,21 @@ export type WhereAssociations<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-  > = {
-    [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
-      infer TDialect,
-      infer TFields,
-      infer TIds,
-      infer TEnums,
-      infer TAssociations,
-      infer TMany,
-      any,
-      any,
-      any
-    >
+> = {
+  [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
+    infer TDialect,
+    infer TFields,
+    infer TIds,
+    infer TEnums,
+    infer TAssociations,
+    infer TMany,
+    any,
+    any,
+    any
+  >
     ? Where<TDialect, TFields, TIds, TEnums, TAssociations> & WhereAggregate<TDialect, TFields, TIds, TEnums, TMany>
     : {}
-  }
+}
 
 export type WhereAggregate<
   TDialect extends Dialect,
@@ -397,15 +397,15 @@ export type WhereAggregate<
   TIds,
   TEnums,
   TMany extends boolean
-  > = TMany extends false
+> = TMany extends false
   ? {}
   : {
-    [AggKey in keyof AggregateFields]?: {
-      [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey]
-      ? WhereFields<TDialect, TFields, TIds, TEnums>[Key]
-      : never
-    }
-  } & { count?: NumberOperators }
+      [AggKey in keyof AggregateFields]?: {
+        [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey]
+          ? WhereFields<TDialect, TFields, TIds, TEnums>[Key]
+          : never
+      }
+    } & { count?: NumberOperators }
 
 export type WhereLogicOperators<
   TDialect extends Dialect,
@@ -419,11 +419,11 @@ export type WhereLogicOperators<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-  > = {
-    or?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
-    and?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
-    not?: Where<TDialect, TFields, TIds, TEnums, TAssociations>
-  }
+> = {
+  or?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
+  and?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
+  not?: Where<TDialect, TFields, TIds, TEnums, TAssociations>
+}
 
 export type FromFindBuilder<T> = T extends FindBuilder<
   any,
@@ -437,8 +437,8 @@ export type FromFindBuilder<T> = T extends FindBuilder<
   infer TLoaded
 >
   ? TMany extends true
-  ? (TSelected & TRawSelected & TLoaded)[]
-  : (TSelected & TRawSelected & TLoaded) | null
+    ? (TSelected & TRawSelected & TLoaded)[]
+    : (TSelected & TRawSelected & TLoaded) | null
   : never
 
 export type FromPaginateBuilder<T> = T extends PaginateBuilder<

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export type Association = {
 export type BuilderOptions = {
   knex: Knex
   dialect: Dialect
-  pubsub?: any
+  pubSub?: any
 }
 
 export type QueryBuilderContext = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export type Association = {
 export type BuilderOptions = {
   knex: Knex
   dialect: Dialect
+  pubsub?: any
 }
 
 export type QueryBuilderContext = {
@@ -154,7 +155,7 @@ export type OrderBy<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-> = OrderByField<TFields> & OrderByAssociation<TAssociations>
+  > = OrderByField<TFields> & OrderByAssociation<TAssociations>
 
 export type OrderByField<TFields extends Record<string, any>> = {
   [Key in keyof TFields]?: OrderByDirection
@@ -168,27 +169,27 @@ export type OrderByAssociation<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-> = {
-  [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
-    any,
-    infer TFields,
-    any,
-    any,
-    any,
-    infer TMany,
-    any,
-    any,
-    any
-  >
+  > = {
+    [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
+      any,
+      infer TFields,
+      any,
+      any,
+      any,
+      infer TMany,
+      any,
+      any,
+      any
+    >
     ? TMany extends true
-      ? {
-          [AggKey in keyof AggregateFields]?: {
-            [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey] ? OrderByDirection : never
-          }
-        } & { count?: OrderByDirection }
-      : { [Key in keyof TFields]?: OrderByDirection }
+    ? {
+      [AggKey in keyof AggregateFields]?: {
+        [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey] ? OrderByDirection : never
+      }
+    } & { count?: OrderByDirection }
+    : { [Key in keyof TFields]?: OrderByDirection }
     : never
-}
+  }
 
 export type Where<
   TDialect extends Dialect,
@@ -202,66 +203,66 @@ export type Where<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-> = WhereFields<TDialect, TFields, TIds, TEnums> &
+  > = WhereFields<TDialect, TFields, TIds, TEnums> &
   WhereAssociations<TAssociations> &
   WhereLogicOperators<TDialect, TFields, TIds, TEnums, TAssociations>
 
 export type WhereFields<TDialect extends Dialect, TFields extends Record<string, any>, TIds, TEnums> = {
   [Key in keyof TFields]?: TDialect extends 'postgres'
-    ? Key extends TIds
-      ? TFields[Key] extends Array<any>
-        ? IdArrayOperators
-        : IdOperators
-      : TFields[Key] extends Array<infer TElement>
-      ? TElement extends TEnums
-        ? EnumArrayOperators<TFields[Key]>
-        : TElement extends boolean
-        ? BooleanArrayOperators
-        : TElement extends number
-        ? NumberArrayOperators
-        : TElement extends string
-        ? StringArrayOperators
-        : never
-      : TFields[Key] extends TEnums
-      ? EnumOperators<TFields[Key]>
-      : TFields[Key] extends boolean
-      ? BooleanOperators
-      : TFields[Key] extends number
-      ? NumberOperators
-      : TFields[Key] extends string
-      ? PgStringOperators
-      : TFields[Key] extends JSON
-      ? JsonOperators
-      : never
-    : TDialect extends 'sqlite'
-    ? Key extends TIds
-      ? TFields[Key] extends Array<any>
-        ? never
-        : IdOperators
-      : TFields[Key] extends TEnums
-      ? EnumOperators<TFields[Key]>
-      : TFields[Key] extends boolean
-      ? BooleanOperators
-      : TFields[Key] extends number
-      ? NumberOperators
-      : TFields[Key] extends string
-      ? StringOperators
-      : never
-    : Key extends TIds
-    ? TFields[Key] extends Array<any>
-      ? never
-      : IdOperators
-    : TFields[Key] extends TEnums
-    ? EnumOperators<TFields[Key]>
-    : TFields[Key] extends boolean
-    ? BooleanOperators
-    : TFields[Key] extends number
-    ? NumberOperators
-    : TFields[Key] extends string
-    ? StringOperators
-    : TFields[Key] extends JSON
-    ? JsonOperators
-    : never
+  ? Key extends TIds
+  ? TFields[Key] extends Array<any>
+  ? IdArrayOperators
+  : IdOperators
+  : TFields[Key] extends Array<infer TElement>
+  ? TElement extends TEnums
+  ? EnumArrayOperators<TFields[Key]>
+  : TElement extends boolean
+  ? BooleanArrayOperators
+  : TElement extends number
+  ? NumberArrayOperators
+  : TElement extends string
+  ? StringArrayOperators
+  : never
+  : TFields[Key] extends TEnums
+  ? EnumOperators<TFields[Key]>
+  : TFields[Key] extends boolean
+  ? BooleanOperators
+  : TFields[Key] extends number
+  ? NumberOperators
+  : TFields[Key] extends string
+  ? PgStringOperators
+  : TFields[Key] extends JSON
+  ? JsonOperators
+  : never
+  : TDialect extends 'sqlite'
+  ? Key extends TIds
+  ? TFields[Key] extends Array<any>
+  ? never
+  : IdOperators
+  : TFields[Key] extends TEnums
+  ? EnumOperators<TFields[Key]>
+  : TFields[Key] extends boolean
+  ? BooleanOperators
+  : TFields[Key] extends number
+  ? NumberOperators
+  : TFields[Key] extends string
+  ? StringOperators
+  : never
+  : Key extends TIds
+  ? TFields[Key] extends Array<any>
+  ? never
+  : IdOperators
+  : TFields[Key] extends TEnums
+  ? EnumOperators<TFields[Key]>
+  : TFields[Key] extends boolean
+  ? BooleanOperators
+  : TFields[Key] extends number
+  ? NumberOperators
+  : TFields[Key] extends string
+  ? StringOperators
+  : TFields[Key] extends JSON
+  ? JsonOperators
+  : never
 }
 
 export type IdOperators = {
@@ -374,21 +375,21 @@ export type WhereAssociations<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-> = {
-  [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
-    infer TDialect,
-    infer TFields,
-    infer TIds,
-    infer TEnums,
-    infer TAssociations,
-    infer TMany,
-    any,
-    any,
-    any
-  >
+  > = {
+    [Key in keyof TAssociations]?: TAssociations[Key][0] extends FindBuilder<
+      infer TDialect,
+      infer TFields,
+      infer TIds,
+      infer TEnums,
+      infer TAssociations,
+      infer TMany,
+      any,
+      any,
+      any
+    >
     ? Where<TDialect, TFields, TIds, TEnums, TAssociations> & WhereAggregate<TDialect, TFields, TIds, TEnums, TMany>
     : {}
-}
+  }
 
 export type WhereAggregate<
   TDialect extends Dialect,
@@ -396,15 +397,15 @@ export type WhereAggregate<
   TIds,
   TEnums,
   TMany extends boolean
-> = TMany extends false
+  > = TMany extends false
   ? {}
   : {
-      [AggKey in keyof AggregateFields]?: {
-        [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey]
-          ? WhereFields<TDialect, TFields, TIds, TEnums>[Key]
-          : never
-      }
-    } & { count?: NumberOperators }
+    [AggKey in keyof AggregateFields]?: {
+      [Key in keyof TFields]?: TFields[Key] extends AggregateFields[AggKey]
+      ? WhereFields<TDialect, TFields, TIds, TEnums>[Key]
+      : never
+    }
+  } & { count?: NumberOperators }
 
 export type WhereLogicOperators<
   TDialect extends Dialect,
@@ -418,11 +419,11 @@ export type WhereLogicOperators<
       PaginateBuilder<any, any, any, any, any, any, any, any, any>
     ]
   >
-> = {
-  or?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
-  and?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
-  not?: Where<TDialect, TFields, TIds, TEnums, TAssociations>
-}
+  > = {
+    or?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
+    and?: Where<TDialect, TFields, TIds, TEnums, TAssociations>[]
+    not?: Where<TDialect, TFields, TIds, TEnums, TAssociations>
+  }
 
 export type FromFindBuilder<T> = T extends FindBuilder<
   any,
@@ -436,8 +437,8 @@ export type FromFindBuilder<T> = T extends FindBuilder<
   infer TLoaded
 >
   ? TMany extends true
-    ? (TSelected & TRawSelected & TLoaded)[]
-    : (TSelected & TRawSelected & TLoaded) | null
+  ? (TSelected & TRawSelected & TLoaded)[]
+  : (TSelected & TRawSelected & TLoaded) | null
   : never
 
 export type FromPaginateBuilder<T> = T extends PaginateBuilder<


### PR DESCRIPTION
# subscribe impl notes
  * added graphql-subscriptions as a **dev** dependency
  * added optional pubsub arg to createSqlMancerClient(); type of *any* (TODO: typedef)
  * added pubsub to options arg that is passed to resolvers
  * added pubsub to BuilderOptions type
  * in tests/postgres/schema.ts I added Subscription type and resolver
    * imported PubSub from graphql-subscriptions; called by resolver
  * created a test (thanks for your help!) in integration.test.js.
  * you'll notice I'm exporting a pubsub instance from schema.js and using that for the tests


# Other miscellaneous stuff
  * I added another test that attempts to use a trigger an event by using an actual mutation, but it doesn't work. It might be something to do with the mock but I didn't get too deep into it.
 * added a testOnly script in package.json that omits the --coverage flag
     * I used `env DB=postgres POSTGRES_PASSWORD=testpassword npm run testOnly integration` to run the tests
 * added sakila.db to .gitignore, because it was an empty file
 
----
I would call this a proof-of-concept implementation, nothing more.  I'm sure there are improvements.

Remaining work:
1. write a test that goes through the client to create a customer and trigger publish()
1. add an argument to publish to pass as subscription payload
1. write implementations for CreateMany, DeleteById, DeleteMany, UpdateById, and UpdateMany
1. implement for other databases

---- 
Question:
Why the heck is setimmediate required in the test? I think this has something to do with lazy initialization of the AsyncIterator returned by graphql-subscriber publish(), but my thinking is pretty fuzzy on how setImmediate resolves that.
